### PR TITLE
新增「答錯歸零」偏好設定（ref bestian/freemath#112）

### DIFF
--- a/src/i18n/en-us/index.js
+++ b/src/i18n/en-us/index.js
@@ -31,5 +31,6 @@ export default {
   'download perfect png fail': 'Could not create image. Please try again.',
   'choose your answer': 'Choose the correct answer',
   'mc.correct': 'Correct!',
-  'mc.wrong': 'Wrong! The answer is {ans}'
+  'mc.wrong': 'Wrong! The answer is {ans}',
+  resetOnWrong: 'Reset streak on wrong answer'
 }

--- a/src/i18n/zh-cn/index.js
+++ b/src/i18n/zh-cn/index.js
@@ -31,5 +31,6 @@ export default {
   'download perfect png fail': '无法生成图片，请重试',
   'choose your answer': '选择正确答案',
   'mc.correct': '答对了！',
-  'mc.wrong': '答错了，正确答案是 {ans}'
+  'mc.wrong': '答错了，正确答案是 {ans}',
+  resetOnWrong: '答错归零'
 }

--- a/src/i18n/zh-tw/index.js
+++ b/src/i18n/zh-tw/index.js
@@ -31,5 +31,6 @@ export default {
   'download perfect png fail': '無法產生圖片，請再試一次',
   'choose your answer': '選擇正確答案',
   'mc.correct': '答對了！',
-  'mc.wrong': '答錯了，正確答案是 {ans}'
+  'mc.wrong': '答錯了，正確答案是 {ans}',
+  resetOnWrong: '答錯歸零'
 }

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -84,6 +84,17 @@
 
         <q-separator spaced />
 
+        <q-item tag="label" class="q-py-sm" clickable>
+          <q-item-section avatar>
+            <q-checkbox v-model="resetOnWrong" color="primary" />
+          </q-item-section>
+          <q-item-section>
+            <q-item-label>{{ $t('resetOnWrong') }}</q-item-label>
+          </q-item-section>
+        </q-item>
+
+        <q-separator spaced />
+
         <q-item class="q-py-sm">
           <q-item-section avatar>
             <q-icon name="calculate" />
@@ -134,7 +145,7 @@
     </q-drawer>
 
     <q-page-container>
-      <router-view :op="op" :mode="mode" :max1="max1" :max2="max2"/>
+      <router-view :op="op" :mode="mode" :max1="max1" :max2="max2" :resetOnWrong="resetOnWrong"/>
     </q-page-container>
   </q-layout>
 </template>
@@ -162,7 +173,8 @@ export default {
       ],
       max1: 20,
       max2: 10,
-      maxs: [5, 10, 20, 50, 100, 500, 1000]
+      maxs: [5, 10, 20, 50, 100, 500, 1000],
+      resetOnWrong: false
     }
   },
   mounted () {

--- a/src/pages/Index.vue
+++ b/src/pages/Index.vue
@@ -171,7 +171,7 @@ import html2canvas from 'html2canvas'
 
 export default {
   name: 'PageIndex',
-  props: ['op', 'max1', 'max2', 'mode'],
+  props: ['op', 'max1', 'max2', 'mode', 'resetOnWrong'],
   data () {
     return {
       n1: 3,
@@ -360,8 +360,10 @@ export default {
           })
         }
       } else {
-        this.winStreak = 0
-        this.streakStartTime = null
+        if (this.resetOnWrong) {
+          this.winStreak = 0
+          this.streakStartTime = null
+        }
         if (this.$q && this.$q.notify) {
           this.$q.notify({
             type: 'negative',
@@ -421,7 +423,10 @@ export default {
             })
           }
         } else {
-          this.winStreak = 0
+          if (this.resetOnWrong) {
+            this.winStreak = 0
+            this.streakStartTime = null
+          }
           this.myAns = null
           this.$q.notify({
             type: 'negative',


### PR DESCRIPTION
based on @Jim-0102 's contribution:

- 預設行為改為答錯不歸零，累積分數可維持
- 設定側邊欄新增核取方塊「答錯歸零」（預設不勾選）
- 勾選後恢復舊行為：答錯立即重設連勝
- 同時套用於選擇題模式與挑戰（填空）模式
- 三語 i18n 翻譯（zh-TW、zh-CN、en-us）